### PR TITLE
docs(readme): reintroduce sections about dockerhub repo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM archlinux:latest
 LABEL maintainer="Gregor Bückendorf"
 ENV container=docker
+
 ENV pip_packages="ansible"
 
 # Install requirements

--- a/README.md
+++ b/README.md
@@ -1,22 +1,33 @@
 # Archlinux Ansible Test Image
 
-![Github Action Workflow Status](https://github.com/gliech/docker-archlinux-ansible/workflows/test/badge.svg)
-![Docker Cloud Build Status](https://img.shields.io/docker/cloud/build/gliech/docker-archlinux-ansible?label=autobuild&logo=docker&logoColor=white)
+[![Github Action Workflow Status](https://github.com/gliech/docker-archlinux-ansible/workflows/test/badge.svg)](https://github.com/gliech/docker-archlinux-ansible/actions?query=branch%3Amaster+workflow%3Atest)
+[![Docker Cloud Build Status](https://img.shields.io/docker/cloud/build/gliech/docker-archlinux-ansible?label=autobuild&logo=docker&logoColor=white)](https://hub.docker.com/r/gliech/docker-archlinux-ansible/builds)
 
 Archlinux Docker container for Ansible playbook and role testing. Adapted from
 [Jeff Geerlings][1] fabulous [container images for ansible testing][2].
 
-## How to Use
+## How to Build
 
-  1. [Install Docker]().
+This image is built on Docker Hub automatically any time the upstream OS
+container is rebuilt, and any time a new release is created in this repository.
+But if you need to build the image on your own locally, do the following:
+
+  1. [Install Docker][3].
   2. `cd` into this directory.
   3. Run `docker build -t archlinux-ansible .`
-  4. Run a container from the image: `docker run --detach --privileged
+
+## How to Use
+
+  1. [Install Docker][3].
+  2. Pull this image from Docker Hub: `docker pull
+     gliech/docker-archlinux-ansible:latest` (or use the image you built
+     earlier, e.g. `archlinux-ansible:latest`).
+  3. Run a container from the image: `docker run --detach --privileged
      --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro
-     archlinux-ansible:latest` (to test Ansible roles, you can
+     gliech/docker-archlinux-ansible:latest` (to test Ansible roles, you can
      add in a volume mounted from the current working directory with
      ``--volume=`pwd`:/etc/ansible/roles/role_under_test:ro``).
-  5. Use Ansible inside the container:
+  4. Use Ansible inside the container:
      1. `docker exec --tty [container_id] env TERM=xterm ansible --version`
      2. `docker exec --tty [container_id] env TERM=xterm ansible-playbook
         /path/to/ansible/playbook.yml --syntax-check`
@@ -28,8 +39,8 @@ Archlinux Docker container for Ansible playbook and role testing. Adapted from
 
 ## Authors
 
-[Original images][2] by [Jeff Geerling][1], author of [Ansible for DevOps][4].
-Adapted for Archlinux by Gregor Bückendorf.
+[Original images][2] and documentation by [Jeff Geerling][1], author of
+[Ansible for DevOps][4]. Adapted for Archlinux by Gregor Bückendorf.
 
 [1]: https://www.jeffgeerling.com/
 [2]: https://ansible.jeffgeerling.com/#container-images-for-ansible-testing


### PR DESCRIPTION
The dockerhub repo is now working as it should, so i can add the original
documentation again.

BREAKING CHANGE: introducing the current state as first stable release